### PR TITLE
[Fix] ListItem modal mismatch

### DIFF
--- a/src/components/list-item.js
+++ b/src/components/list-item.js
@@ -99,7 +99,7 @@ function ListItem({ item, listId, index }) {
     </>
   );
 }
-export default React.memo(ListItem);
+export default ListItem;
 
 const DateContainer = styled.div`
   display: flex;


### PR DESCRIPTION
Memoizing ListItem was causing the item not to update when items are added. There's likely a way around this, but let's remove it for now.